### PR TITLE
CI: exclude master and main branches from running the workflow and allow all others

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,12 @@ name: CI
 
 on:
   pull_request:
-    branches:
-      - main
-      - master
+    # S'exécute sur toutes les pull requests
   push:
-    branches:
+    branches-ignore:
       - main
       - master
+    # S'exécute sur toutes les branches sauf main et master
 
 jobs:
   quality-check:


### PR DESCRIPTION
Now the CI is running on all other branches than master